### PR TITLE
Update bindings to libsession-util @ c73fd92

### DIFF
--- a/src/blinding.cpp
+++ b/src/blinding.cpp
@@ -27,9 +27,9 @@ void pybind_blinding(py::module m) {
             "blind25_id",
             [](py::bytes session_id, py::bytes server_pk) {
                 auto blinded = blind25_id(
-                        usv_from_pybytes(session_id, "session_id", 33, 32),
-                        usv_from_pybytes(server_pk, "server_pk", 32));
-                return py::bytes{from_unsigned(blinded.data()), blinded.size()};
+                        sv_from_pybytes(session_id, "session_id", 33, 32),
+                        sv_from_pybytes(server_pk, "server_pk", 32));
+                return py::bytes{blinded.data(), blinded.size()};
             },
             "session_id"_a,
             "server_pk"_a,
@@ -55,8 +55,8 @@ void pybind_blinding(py::module m) {
             "blind15_key_pair",
             [](py::bytes ed_sk_bytes, py::bytes server_pk) {
                 return std::make_unique<PyKeypair>(blind15_key_pair(
-                        usv_from_pybytes(ed_sk_bytes, "ed25519_seckey", 32, 64),
-                        usv_from_pybytes(server_pk, "server_pk", 32, 64)));
+                        span_u8_from_pybytes(ed_sk_bytes, "ed25519_seckey", 32, 64),
+                        span_u8_from_pybytes(server_pk, "server_pk", 32, 64)));
             },
             "ed25519_seckey"_a,
             "server_pubkey"_a,
@@ -70,8 +70,8 @@ void pybind_blinding(py::module m) {
             "blind25_key_pair",
             [](py::bytes ed_sk_bytes, py::bytes server_pk) {
                 return std::make_unique<PyKeypair>(blind25_key_pair(
-                        usv_from_pybytes(ed_sk_bytes, "ed25519_seckey", 32, 64),
-                        usv_from_pybytes(server_pk, "server_pk", 32, 64)));
+                        span_u8_from_pybytes(ed_sk_bytes, "ed25519_seckey", 32, 64),
+                        span_u8_from_pybytes(server_pk, "server_pk", 32, 64)));
             },
             "ed25519_seckey"_a,
             "server_pubkey"_a,
@@ -84,9 +84,9 @@ void pybind_blinding(py::module m) {
     m.def(
             "blind15_sign",
             [](py::bytes ed_sk_bytes, std::string_view server_pk, py::bytes message) {
-                auto ed_sk = usv_from_pybytes(ed_sk_bytes, "ed25519_seckey", 32, 64);
-                auto sig = blind15_sign(ed_sk, server_pk, usv_from_pybytes(message));
-                return py::bytes{from_unsigned(sig.data()), sig.size()};
+                auto ed_sk = span_u8_from_pybytes(ed_sk_bytes, "ed25519_seckey", 32, 64);
+                auto sig = blind15_sign(ed_sk, server_pk, span_u8_from_pybytes(message));
+                return py::bytes{reinterpret_cast<char*>(sig.data()), sig.size()};
             },
             "ed25519_seckey"_a,
             "server_pubkey"_a,
@@ -106,9 +106,9 @@ void pybind_blinding(py::module m) {
     m.def(
             "blind25_sign",
             [](py::bytes ed_sk_bytes, std::string_view server_pk, py::bytes message) {
-                auto ed_sk = usv_from_pybytes(ed_sk_bytes, "ed25519_seckey", 32, 64);
-                auto sig = blind25_sign(ed_sk, server_pk, usv_from_pybytes(message));
-                return py::bytes{from_unsigned(sig.data()), sig.size()};
+                auto ed_sk = span_u8_from_pybytes(ed_sk_bytes, "ed25519_seckey", 32, 64);
+                auto sig = blind25_sign(ed_sk, server_pk, span_u8_from_pybytes(message));
+                return py::bytes{reinterpret_cast<char*>(sig.data()), sig.size()};
             },
             "ed25519_seckey"_a,
             "server_pubkey"_a,

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -2,6 +2,9 @@
 
 #include <session/util.hpp>
 #include <type_traits>
+#include <string_view>
+#include <span>
+#include <cstdint>
 
 namespace py = pybind11;
 
@@ -10,27 +13,49 @@ using namespace py::literals;
 
 namespace session {
 
-// Takes a py::bytes, returns a ustring_view pointing at its contents.
-inline ustring_view usv_from_pybytes(const py::bytes& in) {
+// Takes a py::bytes, returns a std::string_view pointing at its contents.
+inline std::string_view sv_from_pybytes(const py::bytes& in) {
     char* ptr;
     ssize_t sz;
     PyBytes_AsStringAndSize(in.ptr(), &ptr, &sz);
-    return {to_unsigned(ptr), static_cast<size_t>(sz)};
+    return std::string_view(ptr, static_cast<size_t>(sz));
+}
+
+inline std::span<const uint8_t> span_u8_from_pybytes(const py::bytes& in) {
+    char* ptr;
+    ssize_t sz;
+    PyBytes_AsStringAndSize(in.ptr(), &ptr, &sz);
+    auto result = std::span<const uint8_t>(
+            reinterpret_cast<const uint8_t*>(ptr), static_cast<size_t>(sz));
+    return result;
 }
 
 // Takes a py::bytes, name, and 1+ size arguments: the bytes length must match one of the given
 // sizes, or else an exception will be thrown (referencing the given name, e.g. argument name).
 template <typename... Sizes, typename = std::enable_if_t<(std::is_integral_v<Sizes> && ...)>>
-ustring_view usv_from_pybytes(
+std::string_view sv_from_pybytes(
         const py::bytes& in, std::string_view name, size_t size0, Sizes... moresizes) {
-    auto usv = usv_from_pybytes(in);
-    if (((usv.size() != size0) && ... && (usv.size() != static_cast<size_t>(moresizes)))) {
-        auto err = "invalid bytes size (" + std::to_string(usv.size()) + " for '" +
+    auto sv = sv_from_pybytes(in);
+    if (((sv.size() != size0) && ... && (sv.size() != static_cast<size_t>(moresizes)))) {
+        auto err = "invalid bytes size (" + std::to_string(sv.size()) + " for '" +
                    std::string{name} + "'. Expected one of: " + std::to_string(size0);
         ((void)(err += ", " + std::to_string(moresizes)), ...);
         throw std::invalid_argument{std::move(err)};
     }
-    return usv;
+    return sv;
+}
+
+template <typename... Sizes, typename = std::enable_if_t<(std::is_integral_v<Sizes> && ...)>>
+std::span<const uint8_t> span_u8_from_pybytes(
+        const py::bytes& in, std::string_view name, size_t size0, Sizes... moresizes) {
+    auto sv = span_u8_from_pybytes(in);
+    if (((sv.size() != size0) && ... && (sv.size() != static_cast<size_t>(moresizes)))) {
+        auto err = "invalid bytes size (" + std::to_string(sv.size()) + " for '" +
+                   std::string{name} + "'. Expected one of: " + std::to_string(size0);
+        ((void)(err += ", " + std::to_string(moresizes)), ...);
+        throw std::invalid_argument{std::move(err)};
+    }
+    return sv;
 }
 
 }  // namespace session

--- a/src/onionreq.cpp
+++ b/src/onionreq.cpp
@@ -32,11 +32,11 @@ void pybind(pybind11::module m) {
                              py::bytes privkey_b,
                              py::bytes request_b,
                              size_t max_size) {
-                     auto pubkey = usv_from_pybytes(pubkey_b, "x25519_pubkey", 32);
-                     auto privkey = usv_from_pybytes(privkey_b, "x25519_privkey", 32);
-                     auto request = usv_from_pybytes(request_b);
+                     auto pubkey = span_u8_from_pybytes(pubkey_b, "x25519_pubkey", 32);
+                     auto privkey = span_u8_from_pybytes(privkey_b, "x25519_privkey", 32);
+                     auto request = span_u8_from_pybytes(request_b);
                      PyOnionReqParser parser{pubkey, privkey, request, max_size};
-                     ustring pl = parser.move_payload();
+                     std::vector<uint8_t> pl = parser.move_payload();
                      parser.payload_b =
                              py::bytes{reinterpret_cast<const char*>(pl.data()), pl.size()};
                      return parser;
@@ -64,7 +64,7 @@ void pybind(pybind11::module m) {
             .def(
                     "encrypt_reply",
                     [](const PyOnionReqParser& parser, py::bytes reply) {
-                        auto encr = parser.encrypt_reply(usv_from_pybytes(reply));
+                    std::vector<uint8_t> encr = parser.encrypt_reply(span_u8_from_pybytes(reply));
                         return py::bytes{reinterpret_cast<const char*>(encr.data()), encr.size()};
                     },
                     "reply"_a,

--- a/src/xed25519.cpp
+++ b/src/xed25519.cpp
@@ -12,8 +12,8 @@ void pybind(pybind11::module m) {
     m.def(
             "sign",
             [](py::bytes x25519_privkey, py::bytes msg) {
-                auto a = usv_from_pybytes(x25519_privkey, "x25519_privkey", 32);
-                auto sig = sign(a, usv_from_pybytes(msg));
+                auto a = sv_from_pybytes(x25519_privkey, "x25519_privkey", 32);
+                auto sig = sign(a, sv_from_pybytes(msg));
                 return py::bytes(reinterpret_cast<const char*>(sig.data()), sig.size());
             },
             "x25519_privkey"_a,
@@ -23,7 +23,7 @@ void pybind(pybind11::module m) {
     m.def(
             "pubkey",
             [](py::bytes x25519_pubkey) {
-                auto A = usv_from_pybytes(x25519_pubkey, "x25519_pubkey", 32);
+                auto A = sv_from_pybytes(x25519_pubkey, "x25519_pubkey", 32);
                 auto edpk = pubkey(A);
                 return py::bytes(reinterpret_cast<const char*>(edpk.data()), edpk.size());
             },
@@ -38,9 +38,9 @@ void pybind(pybind11::module m) {
     m.def(
             "verify",
             [](py::bytes signature, py::bytes x25519_pubkey, py::bytes msg) {
-                auto sig = usv_from_pybytes(signature, "signature", 64);
-                auto A = usv_from_pybytes(x25519_pubkey, "x25519_pubkey", 32);
-                return verify(sig, A, usv_from_pybytes(msg));
+                auto sig = sv_from_pybytes(signature, "signature", 64);
+                auto A = sv_from_pybytes(x25519_pubkey, "x25519_pubkey", 32);
+                return verify(sig, A, sv_from_pybytes(msg));
             },
             "signature"_a,
             "x25519_pubkey"_a,


### PR DESCRIPTION
ustring_view was removed awhile back now, APIs want to sometimes take a std::string_view and some of them want std::span<uint8_t> so update the bindings to have helper functions to convert into those formats and pass them down in libsession.